### PR TITLE
Fabio/th 734 prompt studio lets you run prompts even when your credit is

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@toolhouseai/sdk",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Toolhouse typescript sdk",
   "source": "./src/index.ts",
   "main": "./dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,7 +96,7 @@ export class Toolhouse {
               return data?.content.content
             } catch (error) {
               if (error && (error as ToolhouseError).metadata?.status === 402) {
-                return `ERROR: Notify User that need to add credits to their account with the message <message>Unable to execute ${tool.name} tool. Your account ran out of Toolhouse Execs. Please visit https://app.toolhouse.ai/billing to top up your Execs balance.<\message>`
+                return `ERROR: Notify the user to add Toolhouse Execution credits (Execs) to their account with the message: Unable to execute the ${tool.name} tool. Your account has run out of Toolhouse Execs. Please visit https://app.toolhouse.ai/billing to top up your Execs balance.`
               }
               return null
             }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,12 @@ import Anthropic from '@anthropic-ai/sdk';
 
 export type * from './http';
 
+interface ToolhouseError {
+  metadata: {
+    status: number;
+  };
+}
+
 export class Toolhouse {
   private _provider: ProviderTypes;
   private _metadata: MetadataType;
@@ -89,7 +95,9 @@ export class Toolhouse {
               const { data } = await this.serviceTools.runTools(toolBody, requestConfig)
               return data?.content.content
             } catch (error) {
-              console.error(`Error during tool '${tool.name}' execution:`, error)
+              if (error && (error as ToolhouseError).metadata?.status === 402) {
+                return `ERROR: Notify User that need to add credits to their account with the message <message>Unable to execute ${tool.name} tool. Your account ran out of Toolhouse Execs. Please visit https://app.toolhouse.ai/billing to top up your Execs balance.<\message>`
+              }
               return null
             }
           }


### PR DESCRIPTION
This PR fixes an issue where the SDK did not return an error when credits were exhausted while using the Vercel provider. The SDK now notifies the user to add more Toolhouse Execution credits (Execs) by returning the following error message:

`ERROR: Notify the user to add Toolhouse Execution credits (Execs) to their account with the message: Unable to execute the ${tool.name} tool. Your account has run out of Toolhouse Execs. Please visit https://app.toolhouse.ai/billing to top up your Execs balance.`

With this enhancement, once credits are exhausted, the LLM will properly inform users that they must add additional Execs to continue using the service.